### PR TITLE
Handle pagination of results

### DIFF
--- a/ecr.go
+++ b/ecr.go
@@ -47,21 +47,26 @@ func configure(awsAccessKeyID *string, awsSecretAccessKey *string, region *strin
 
 func checkImageExists(cfg *aws.Config, repositoryName *string, imageTag *string) {
 	svc := ecr.NewFromConfig(*cfg)
-	out, err := svc.ListImages(
-		context.TODO(),
+	paginator := ecr.NewListImagesPaginator(
+		svc,
 		&ecr.ListImagesInput{
 			RepositoryName: repositoryName,
 		},
 	)
-	if err != nil {
-		log.Fatal(err)
-	}
-	for _, image := range out.ImageIds {
-		if *image.ImageTag == *imageTag {
-			fmt.Println("1")
-			return
+
+	for paginator.HasMorePages() {
+		out, err := paginator.NextPage(context.TODO())
+		if err != nil {
+			log.Fatal(err)
+		}
+		for _, image := range out.ImageIds {
+			if *image.ImageTag == *imageTag {
+				fmt.Println("1")
+				return
+			}
 		}
 	}
+
 	fmt.Println("0")
 	return
 }


### PR DESCRIPTION
Previously, the code was only checking the first page of results from the API, which is 100 images.  This provides a lot of opportunity for incorrect results when the number of images in a repository grows larger than 100.

Now we create a paginator object and use that to iterate through all of the images.  This may take longer, especially for non-existent tags, since we have to make more API calls, but it's necessary for accuracy.

Relevant documentation:
  * https://aws.github.io/aws-sdk-go-v2/docs/making-requests/#using-paginators
  * https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/ecr#ListImagesPaginator