### PR TITLE
Fix nil pointer dereference

### DIFF
--- a/ecr.go
+++ b/ecr.go
@@ -60,7 +60,7 @@ func checkImageExists(cfg *aws.Config, repositoryName *string, imageTag *string)
 			log.Fatal(err)
 		}
 		for _, image := range out.ImageIds {
-			if *image.ImageTag == *imageTag {
+			if image.ImageTag != nil && *image.ImageTag == *imageTag {
 				fmt.Println("1")
 				return
 			}


### PR DESCRIPTION
Starting last week, our build jobs began failing.  Running it locally reproduced fairly easily:

    ┌─[jamesph@Jamess-MBP] - [~/Documents/github-actions-check-ecr-image-exists] - [Tue Jan 24, 11:27]
    └─[$]> go run ecr.go <snipped args>
    panic: runtime error: invalid memory address or nil pointer dereference
    [signal SIGSEGV: segmentation violation code=0x2 addr=0x8 pc=0x1031eee38]

    goroutine 1 [running]:
    main.checkImageExists(0x1400011b960?, 0x1400011b990, 0x1400011b9a0)
            /Users/jamesph/Documents/github-actions-check-ecr-image-exists/ecr.go:63 +0x1b8
    main.main()
            /Users/jamesph/Documents/github-actions-check-ecr-image-exists/ecr.go:27 +0x1b0
    exit status 2

Looking at it in delve we can see that there was an image with no tag:

    (dlv) locals
    svc = ("*github.com/aws/aws-sdk-go-v2/service/ecr.Client")(0x140001f5cc0)
    paginator = ("*github.com/aws/aws-sdk-go-v2/service/ecr.ListImagesPaginator")(0x140002505a0)
    err = error nil
    out = ("*github.com/aws/aws-sdk-go-v2/service/ecr.ListImagesOutput")(0x14000113170)
    image = github.com/aws/aws-sdk-go-v2/service/ecr/types.ImageIdentifier {ImageDigest: (*string)(0x1400030cac0), ImageTag: *string nil, noSmithyDocumentSerde: github.com/aws/smithy-go/document.NoSerde {}}

Indeed, looking in the ECR console, there are a couple of images with no tags.  Why we're pushing no-tag images is a separate issue to look at, but this check script should handle that gracefully.

Fixes mnmandahalf/check-ecr-image-exists#3